### PR TITLE
use standard bunyan response serializer + allow overriding serializers

### DIFF
--- a/lib/fh_logger.js
+++ b/lib/fh_logger.js
@@ -60,9 +60,9 @@ function configureStreams(config) {
 }
 
 function configureSerializers(config) {
-  config.serializers = {
-    req: requestSerializer
-  };
+  config.serializers = config.serializers || {};
+  config.serializers.req = config.serializers.req || requestSerializer;
+  config.serializers.res = config.serializers.res || bunyan.stdSerializers.res;
 }
 
 var requestSerializer = function(req) {


### PR DESCRIPTION
this is needed to get response logging a lot less verbose in

https://github.com/fheng/fh-messaging/pull/47/files#r42263687

you can see samples before and after this patch here:

https://gist.github.com/lfryc/d39ef61d71ea03cceb82

this patch also allows to pass custom serializers to configuration and `configureSerializers` will extend them, not override them
