### PR TITLE
Making a copy of the config object to not modify it.

### DIFF
--- a/lib/fh_logger.js
+++ b/lib/fh_logger.js
@@ -28,7 +28,8 @@ module.exports.createLogger = function(loggerConfig) {
 }
 
 function parseConfig(loggerConfig) {
-  return typeof loggerConfig === 'string' ? JSON.parse(loggerConfig) : loggerConfig;
+  var config = typeof loggerConfig !== 'string' ? JSON.stringify(loggerConfig) : loggerConfig;
+  return JSON.parse(config);
 }
 
 function createStreams(config) {

--- a/test/test_fh_logger.js
+++ b/test/test_fh_logger.js
@@ -37,6 +37,15 @@ describe('fh_logger', function() {
       });
     });
 
+    describe('should make copy of provided config', function() {
+      it('config should not be modified when passed to createLogger function', function() {
+        var config = {name: 'simple'};
+        expect(Object.keys(config).length).to.equal(1);
+        var logger = fh_logger.createLogger(config);
+        expect(Object.keys(config).length).to.equal(1);
+      });
+    });
+
     describe('with Bunyan defaults', function() {
       var logger;
       before(function(){


### PR DESCRIPTION
Motivation:
Currently, the createLogger function will modify the passed in config
object. This might not be expected by the caller and could also cause
issue if this instance is later updated from the outide.
Instead a copy of the config should be taken and used by the logger.

Modifications:
Added a copy of when the config object is not a string.

Result:
The passed-in config object will not be modified by the createLogger
function.
