### PR TITLE
Adding missing semicolons as reported by Sonarqube

### DIFF
--- a/lib/fh_logger.js
+++ b/lib/fh_logger.js
@@ -25,7 +25,7 @@ module.exports.createLogger = function(loggerConfig) {
   config.streams = createStreams(config);
   config.serializers = createSerializers(config);
   return bunyan.createLogger(config);
-}
+};
 
 function parseConfig(loggerConfig) {
   var config = typeof loggerConfig !== 'string' ? JSON.stringify(loggerConfig) : loggerConfig;
@@ -86,7 +86,7 @@ var requestSerializer = function(req) {
       method: req.method,
       url: req.url,
       worker: cluster.worker? cluster.worker.id: -1
-    }
+    };
   }
-  return {}
-}
+  return {};
+};


### PR DESCRIPTION
Motivation:
Leigh gave a demo of Sonarqube yesterday and when looking at fh-logger I
noticed there this issue:
https://metrics.skunkhenry.com/dashboard/index/3245

Modifications:
Adding the semicolons that were reported missing.

Result:
JSHint should still pass:
$ grunt jshint
And unit test should still pass:
$ grunt
