### PR TITLE
[RHMAP 7582] Add express request id functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,34 @@ To run all the tests:
 grunt mochaTest
 ```
 
+#### Request Id logging
+`fh-loggger` also exports express-compatible middleware to generate unique requestId and automatically include it in logging methods.
 
+```
+var fh_logger = require('fh-logger');
+
+// must be called to setup the middleware
+var logger = fh_logger.createLogger({
+  name: 'first',
+  requestIdHeader: 'X-SOME-HTTP-HEADER'
+});
+app.use(logger.requestIdMiddleware);
+app.get('/', function(req, res) {
+  console.log(req.requestId) // -> uuid
+  logger.info('some message') // -> {msg: 'some message', requestId: 'some-uuid'}
+})
+```
+
+By default it utilizes the 'X-FH-REQUEST-ID' header, this can be overridden by the configuration passed to `createLogger` as shown above
+
+##### ensureRequestId
+
+For logging inside callbacks that are supposed to display the `requestId` but for some reason do not, utilize the exported `ensureRequestId({Function})`:
+
+```
+logger.ensureRequestId(function asyncOperation(err, data){
+  logger.error(err); // -> {requestId: 'some-uuid'}
+});
+```
+
+For more information refer to the [continuation-local-storage module docs](https://github.com/othiym23/node-continuation-local-storage#namespacebindcallback-context)

--- a/lib/const.json
+++ b/lib/const.json
@@ -1,19 +1,3 @@
-/*
- JBoss, Home of Professional Open Source
- Copyright Red Hat, Inc., and individual contributors.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-*/
 {
   "namespace": "com.feedhenry.fh-logger"
 }

--- a/lib/const.json
+++ b/lib/const.json
@@ -1,0 +1,19 @@
+/*
+ JBoss, Home of Professional Open Source
+ Copyright Red Hat, Inc., and individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+{
+  "namespace": "com.feedhenry.fh-logger"
+}

--- a/lib/fh_logger.js
+++ b/lib/fh_logger.js
@@ -16,6 +16,7 @@
 */
 var bunyan = require('bunyan');
 var cluster = require('cluster');
+var requestIdDecorate = require('./request-id/decorateLogger');
 
 module.exports.createLogger = function(loggerConfig) {
   if (!loggerConfig) {
@@ -24,8 +25,17 @@ module.exports.createLogger = function(loggerConfig) {
   var config = parseConfig(loggerConfig);
   config.streams = createStreams(config);
   config.serializers = createSerializers(config);
-  return bunyan.createLogger(config);
+  var logger = bunyan.createLogger(config);
+
+  // initialize requestId related submodules
+  logger.requestIdMiddleware = require('./request-id/middleware')(config);
+  requestIdDecorate(logger);
+  module.exports.requestIdMiddleware = logger.requestIdMiddleware;
+  module.exports.ensureRequestId = logger.ensureRequestId;
+
+  return logger;
 };
+
 
 function parseConfig(loggerConfig) {
   var config = typeof loggerConfig !== 'string' ? JSON.stringify(loggerConfig) : loggerConfig;

--- a/lib/request-id/decorateLogger.js
+++ b/lib/request-id/decorateLogger.js
@@ -1,0 +1,66 @@
+/*
+ JBoss, Home of Professional Open Source
+ Copyright Red Hat, Inc., and individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+var cls = require('continuation-local-storage');
+var namespace = require('../const').namespace;
+
+function retrieveRequestId() {
+  var ns = cls.getNamespace(namespace);
+  if (!ns) {
+    // namespace not initialized, outside of request chain
+    return;
+  }
+  var id = ns.get('requestId');
+  return id;
+}
+
+var loggingFunctions = [
+  'fatal',
+  'error',
+  'warn',
+  'info',
+  'debug',
+  'trace'
+];
+
+/**
+ * Overrides the logging functions to delegate to a 'simple' child that has the requestId bound at invocation time.
+ * This seems the simplest way to have a dynamically bound field on a bunyan logger
+ * According to the internal documentation, creation for 'simple' children is much more performant
+ *
+ * The promising alternative was using bunyan serializers, but they only run once on logger creation
+ *
+ * @param  {bunyan.Logger} logger Logger instance to decorate
+ */
+module.exports = function(logger) {
+  loggingFunctions.forEach(function(f) {
+    var originalFunction = logger[f];
+    logger[f] = function() {
+      var id = retrieveRequestId();
+      // call the original if outside of a request chain
+      if (!id) {
+        return originalFunction.apply(logger, arguments);
+      }
+      // use simpleChild flag for performance
+      var child = logger.child({requestId: retrieveRequestId()}, true);
+      child[f].apply(child, arguments);
+    };
+
+    // expose namespace binding for client use
+    var ns = cls.getNamespace(namespace);
+    logger.ensureRequestId = ns.bind.bind(ns);
+  });
+};

--- a/lib/request-id/decorateLogger.js
+++ b/lib/request-id/decorateLogger.js
@@ -60,13 +60,12 @@ module.exports = function(logger) {
     };
 
     // expose namespace binding for client use
-    var ns = cls.getNamespace(namespace);
-    if (ns) {
-      logger.ensureRequestId = ns.bind.bind(ns);
-    } else {
-      logger.ensureRequestId = function(cb) {
-        cb();
-      };
-    }
+    logger.ensureRequestId = function(cb) {
+      var ns = cls.getNamespace(namespace);
+      if (!ns) {
+        return cb;
+      }
+      return ns.bind.call(ns, cb);
+    };
   });
 };

--- a/lib/request-id/decorateLogger.js
+++ b/lib/request-id/decorateLogger.js
@@ -61,6 +61,12 @@ module.exports = function(logger) {
 
     // expose namespace binding for client use
     var ns = cls.getNamespace(namespace);
-    logger.ensureRequestId = ns.bind.bind(ns);
+    if (ns) {
+      logger.ensureRequestId = ns.bind.bind(ns);
+    } else {
+      logger.ensureRequestId = function(cb) {
+        cb();
+      };
+    }
   });
 };

--- a/lib/request-id/middleware.js
+++ b/lib/request-id/middleware.js
@@ -28,16 +28,12 @@ var namespace = require('../const').namespace;
  */
 module.exports = function(config) {
   var header = config.requestIdHeader || 'X-FH-REQUEST-ID';
-  return function(req, res, next) {
+  var middleware = function(req, res, next) {
+    var id = req.header(header) || uuid.v4();
     var ns = cls.createNamespace(namespace);
     ns.bindEmitter(req);
     ns.bindEmitter(res);
     ns.run(function() {
-      var id = uuid.v4();
-      if (req.header(header)) {
-        ns.set('requestId', req.header(header));
-        return next();
-      }
       ns.set('requestId', id);
 
       // also insert the request id in the Request object for convenience
@@ -47,4 +43,6 @@ module.exports = function(config) {
       return next();
     });
   };
+  middleware.header = header;
+  return middleware;
 };

--- a/lib/request-id/middleware.js
+++ b/lib/request-id/middleware.js
@@ -1,0 +1,50 @@
+/*
+ JBoss, Home of Professional Open Source
+ Copyright Red Hat, Inc., and individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+var uuid = require('node-uuid');
+var cls = require('continuation-local-storage');
+var namespace = require('../const').namespace;
+
+/**
+ * Builds an express middleware that inserts the requestId in the request
+ * and stores it for use in other logger invocations
+ *
+ * Should be `use`d near the start of the middleware chain
+ * @param  {Object} config Logger configuration, uses config.requestIdHeader as the header key for the requestId
+ * @return {Function}        Express.js middleware
+ */
+module.exports = function(config) {
+  var header = config.requestIdHeader || 'X-FH-REQUEST-ID';
+  return function(req, res, next) {
+    var ns = cls.createNamespace(namespace);
+    ns.bindEmitter(req);
+    ns.bindEmitter(res);
+    ns.run(function() {
+      var id = uuid.v4();
+      if (req.header(header)) {
+        ns.set('requestId', req.header(header));
+        return next();
+      }
+      ns.set('requestId', id);
+
+      // also insert the request id in the Request object for convenience
+      // and access by other modules
+      req.requestId = id;
+
+      return next();
+    });
+  };
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "fh-logger",
-  "version": "0.2.0",
+  "version": "0.4.1",
   "dependencies": {
     "bunyan": {
-      "version": "1.5.1",
+      "version": "1.8.1",
       "from": "bunyan@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
       "dependencies": {
         "dtrace-provider": {
           "version": "0.6.0",
@@ -13,9 +13,9 @@
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
           "dependencies": {
             "nan": {
-              "version": "2.1.0",
+              "version": "2.3.5",
               "from": "nan@>=2.0.8 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
             }
           }
         },
@@ -42,24 +42,24 @@
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
             },
             "rimraf": {
-              "version": "2.4.3",
+              "version": "2.4.5",
               "from": "rimraf@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "version": "6.0.4",
+                  "from": "glob@>=6.0.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                   "dependencies": {
                     "inflight": {
-                      "version": "1.0.4",
+                      "version": "1.0.5",
                       "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
+                          "version": "1.0.2",
                           "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
@@ -69,19 +69,19 @@
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
-                      "version": "3.0.0",
+                      "version": "3.0.2",
                       "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.1",
+                          "version": "1.1.5",
                           "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                              "version": "0.4.1",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
@@ -93,14 +93,14 @@
                       }
                     },
                     "once": {
-                      "version": "1.3.2",
+                      "version": "1.3.3",
                       "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
+                          "version": "1.0.2",
                           "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
@@ -119,8 +119,49 @@
           "version": "1.0.3",
           "from": "safe-json-stringify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
+        },
+        "moment": {
+          "version": "2.13.0",
+          "from": "moment@>=2.10.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
         }
       }
+    },
+    "continuation-local-storage": {
+      "version": "3.1.7",
+      "from": "continuation-local-storage@>=3.1.7 <4.0.0",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+      "dependencies": {
+        "async-listener": {
+          "version": "0.6.0",
+          "from": "async-listener@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+          "dependencies": {
+            "shimmer": {
+              "version": "1.0.0",
+              "from": "shimmer@1.0.0",
+              "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+            }
+          }
+        },
+        "emitter-listener": {
+          "version": "1.0.1",
+          "from": "emitter-listener@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+          "dependencies": {
+            "shimmer": {
+              "version": "1.0.0",
+              "from": "shimmer@1.0.0",
+              "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "node-uuid": {
+      "version": "1.4.7",
+      "from": "node-uuid@>=1.4.7 <2.0.0",
+      "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-logger",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "dependencies": {
     "bunyan": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "version": "sed -i.bak \"s/sonar.projectVersion=.*/sonar.projectVersion=${npm_package_version}/\" sonar-project.properties && rm sonar-project.properties.bak && git add sonar-project.properties"
   },
   "dependencies": {
-    "bunyan": "^1.5.1"
+    "bunyan": "^1.5.1",
+    "continuation-local-storage": "^3.1.7",
+    "node-uuid": "^1.4.7"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-logger",
   "description": "Enables a simple way of configuring and creating loggers, configured with request serializers, including clustering information.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-logger.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-logger
 sonar.projectName=fh-logger-nightly-master
-sonar.projectVersion=0.4.1
+sonar.projectVersion=0.5.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/test_fh_logger.js
+++ b/test/test_fh_logger.js
@@ -92,6 +92,9 @@ describe('fh_logger', function() {
       it('path should be '  + logFile, function() {
         expect(logger.streams[0].path).to.equal(logFile);
       });
+      after(function(done) {
+        fs.unlink(logFile, done);
+      });
     });
 
     describe('using file type from string configuration', function() {

--- a/test/test_request-id.js
+++ b/test/test_request-id.js
@@ -1,0 +1,48 @@
+/*
+ JBoss, Home of Professional Open Source
+ Copyright Red Hat, Inc., and individual contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+var expect = require('chai').expect;
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var requestIdMiddleware = require('../lib/request-id/middleware');
+var cls = require('continuation-local-storage');
+var namespace = require('../lib/const').namespace;
+
+describe('request-id middleware', function() {
+  var customHeader = 'X-CUSTOM-REQUEST-ID';
+  var cfg = {
+    requestIdHeader: customHeader
+  };
+
+  var mockReq = new EventEmitter();
+  mockReq.header = function() {
+    return 'some-uuid';
+  }
+
+  before(function() {
+    this.middleware = requestIdMiddleware(cfg);
+  });
+  it('should accept a header config', function() {
+    expect(this.middleware.header).to.equal(customHeader);
+  });
+  it('should populate the request id', function(done) {
+    this.middleware(mockReq, new EventEmitter(), function next() {
+      var ns = cls.getNamespace(namespace);
+      expect(ns.get('requestId')).to.equal('some-uuid');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Expose request id tracking functionality through HTTP header and `process`-wide storage, to allow for logging clients to include this data with as little modification as possible.
# Changes
- Added necessary dependencies
- Add request-id folder with implementation
- Update README with docs and example usage
- Minor version bump

ping @nialldonnellyfh @danbev
