### PR TITLE
Single function to get logger namespace.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ plato/
 coverage/
 *.swp
 cov-*
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     _test_runner: '_mocha',
     _istanbul: 'istanbul cover --dir',
-    _unit_args: '--recursive -t 10000 ./test/test_request-id.js',
+    _unit_args: '--recursive -t 10000 ./test/',
     unit: '<%= _test_runner %> <%= _unit_args %>',
     unit_cover: '<%= _istanbul %> cov-unit <%= _test_runner %> -- <%= _unit_args %>',
     mochaTest: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     _test_runner: '_mocha',
     _istanbul: 'istanbul cover --dir',
-    _unit_args: '--recursive -t 10000 ./test/',
+    _unit_args: '--recursive -t 10000 ./test/test_request-id.js',
     unit: '<%= _test_runner %> <%= _unit_args %>',
     unit_cover: '<%= _istanbul %> cov-unit <%= _test_runner %> -- <%= _unit_args %>',
     mochaTest: {

--- a/lib/request-id/decorateLogger.js
+++ b/lib/request-id/decorateLogger.js
@@ -14,17 +14,16 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-var cls = require('continuation-local-storage');
-var namespace = require('../const').namespace;
+
+var getLoggerNamespace = require('./loggerNamespace');
 
 function getRequestId() {
-  var ns = cls.getNamespace(namespace);
+  var ns = getLoggerNamespace();
   if (!ns) {
     // namespace not initialized, outside of request chain
     return;
   }
-  var id = ns.get('requestId');
-  return id;
+  return ns.get('requestId');
 }
 
 /**
@@ -34,10 +33,7 @@ function getRequestId() {
  * @param {Function} cb Callback to run with the requestId set
  */
 function setRequestId(id, cb) {
-  var ns = cls.getNamespace(namespace);
-  if (!ns) {
-    ns = cls.createNamespace(namespace);
-  }
+  var ns = getLoggerNamespace();
   ns.run(function() {
     ns.set('requestId', id);
     cb();
@@ -50,7 +46,7 @@ function setRequestId(id, cb) {
  * @return {Function}      callback bound in namespace
  */
 function ensureRequestId(cb) {
-  var ns = cls.getNamespace(namespace);
+  var ns = getLoggerNamespace();
   if (!ns) {
     return cb;
   }
@@ -79,6 +75,7 @@ module.exports = function(logger) {
   // expose the request id for forwarding via HTTP requests
   logger.getRequestId = getRequestId;
   logger.setRequestId = setRequestId;
+  logger.getLoggerNamespace = getLoggerNamespace;
   logger.ensureRequestId = ensureRequestId;
   loggingFunctions.forEach(function(f) {
     var originalFunction = logger[f];

--- a/lib/request-id/loggerNamespace.js
+++ b/lib/request-id/loggerNamespace.js
@@ -1,0 +1,12 @@
+var cls = require('continuation-local-storage');
+var namespace = require('../const').namespace;
+var ns;
+
+
+module.exports = function getLoggerNamespace() {
+  if (!ns) {
+    ns = cls.createNamespace(namespace);
+  }
+
+  return ns;
+};

--- a/lib/request-id/middleware.js
+++ b/lib/request-id/middleware.js
@@ -15,8 +15,7 @@
  limitations under the License.
 */
 var uuid = require('node-uuid');
-var cls = require('continuation-local-storage');
-var namespace = require('../const').namespace;
+var getLoggerNamespace = require('./loggerNamespace');
 
 /**
  * Builds an express middleware that inserts the requestId in the request
@@ -30,7 +29,7 @@ module.exports = function(config) {
   var header = config.requestIdHeader || 'X-FH-REQUEST-ID';
   var middleware = function(req, res, next) {
     var id = req.header(header) || uuid.v4();
-    var ns = cls.createNamespace(namespace);
+    var ns = getLoggerNamespace();
     ns.bindEmitter(req);
     ns.bindEmitter(res);
     ns.run(function() {

--- a/test/test_request-id.js
+++ b/test/test_request-id.js
@@ -15,7 +15,6 @@
  limitations under the License.
 */
 var expect = require('chai').expect;
-var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var requestIdMiddleware = require('../lib/request-id/middleware');
 var cls = require('continuation-local-storage');


### PR DESCRIPTION
This allows the component requiring the logger to get the namespace.

This is needed for changes in fh-supercore.
