### PR TITLE
[RHMAP 8262] Connect compatibility

### DIFF
--- a/lib/request-id/middleware.js
+++ b/lib/request-id/middleware.js
@@ -30,7 +30,15 @@ module.exports = function(config) {
   config = config || {};
   var header = config.requestIdHeader || 'X-FH-REQUEST-ID';
   var middleware = function(req, res, next) {
-    var id = req.header(header) || uuid.v4();
+    var id;
+    if (typeof req.header === 'function') {
+      id = req.header(header);
+    } else {
+      // support connect middleware
+      id = req.headers[header];
+    }
+
+    id = id  || uuid.v4();
     var ns = getLoggerNamespace();
     if (req instanceof EventEmitter) {
       ns.bindEmitter(req);


### PR DESCRIPTION
Add check to make middleware compatible with `connect`'s middleware's request object (`http.IncomingRequest`) instead of just `express`'.
