### PR TITLE
Adding the request ID to all responses for easier debugging

### DIFF
--- a/lib/request-id/middleware.js
+++ b/lib/request-id/middleware.js
@@ -39,6 +39,7 @@ module.exports = function(config) {
     }
 
     id = id  || uuid.v4();
+
     var ns = getLoggerNamespace();
     if (req instanceof EventEmitter) {
       ns.bindEmitter(req);
@@ -46,6 +47,15 @@ module.exports = function(config) {
     if (res instanceof EventEmitter) {
       ns.bindEmitter(res);
     }
+
+    //Setting the request ID on the response headers. Allows for easier debugging
+    // Expressjs 4.0 uses res.set and connect uses res.setHeader
+    if (typeof res.set === 'function') {
+      res.set(header, id);
+    } else {
+      res.setHeader(header, id);
+    }
+
     ns.run(function() {
       ns.set('requestId', id);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-logger",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "dependencies": {
     "bunyan": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-logger",
   "description": "Enables a simple way of configuring and creating loggers, configured with request serializers, including clustering information.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-logger.git"
@@ -31,6 +31,7 @@
     "grunt-mocha-test": "^0.12.7",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
-    "rewire": "^2.3.4"
+    "rewire": "^2.3.4",
+    "sinon": "1.17.5"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-logger
 sonar.projectName=fh-logger-nightly-master
-sonar.projectVersion=0.5.0
+sonar.projectVersion=0.5.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

Including the request ID in the response headers will make it easier for users to identify the ID of a request for debugging.
# Changes
- Updated the middleware to set the relevant request ID on the response object. This handles both expressjs 4 and connect.
