### PR TITLE
Added lower case header accessor for connect middleware

### DIFF
--- a/lib/request-id/middleware.js
+++ b/lib/request-id/middleware.js
@@ -35,7 +35,12 @@ module.exports = function(config) {
       id = req.header(header);
     } else {
       // support connect middleware
-      id = req.headers[header];
+      // Only uses lower-case headers.
+      if (header.toLowerCase) {
+        id = req.headers[header.toLowerCase()];
+      } else {
+        id = req.headers[header];
+      }
     }
 
     id = id  || uuid.v4();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-logger",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "dependencies": {
     "bunyan": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-logger",
   "description": "Enables a simple way of configuring and creating loggers, configured with request serializers, including clustering information.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/feedhenry/fh-logger.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-logger
 sonar.projectName=fh-logger-nightly-master
-sonar.projectVersion=0.5.1
+sonar.projectVersion=0.5.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/test_request-id.js
+++ b/test/test_request-id.js
@@ -61,4 +61,31 @@ describe('request-id middleware', function() {
       done();
     });
   });
+
+  it('should populate the request id for connect middleware', function(done) {
+    var setHeaderSpy = sinon.spy();
+
+    var mockReq = new EventEmitter();
+    var mockReqIdLc = "somelowercase";
+
+    mockReq.headers = {
+      'x-custom-request-id': mockReqIdLc
+    };
+    var mockRes = {
+      setHeader: setHeaderSpy
+    };
+
+
+    this.middleware(mockReq, mockRes, function next() {
+      var ns = cls.getNamespace(namespace);
+      expect(ns.get('requestId')).to.equal(mockReqIdLc);
+      expect(logger.createLogger({name: 'test'}).getRequestId()).to.equal(mockReqIdLc);
+
+      //The response headers should have been set.
+      sinon.assert.calledOnce(setHeaderSpy);
+      sinon.assert.calledWith(setHeaderSpy, sinon.match(customHeader), sinon.match(mockReqIdLc));
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
# Motivation

Connect is converting headers to lower case in fh-scm.
# Change

Converting the header name to lower case if it is for the connect middleware.
